### PR TITLE
Fix: Correctly get alpnProtocol

### DIFF
--- a/src/initMiddleware.js
+++ b/src/initMiddleware.js
@@ -9,11 +9,10 @@ function initMiddleware (app) {
         res.req = req;
         req.next = next;
 
-        const { socket } = req.httpVersion === '2.0' ?
-                                req.stream.session : req;
+        const alpnProtocol = req?.stream?.session?.alpnProtocol;
 
         //Checking alpnProtocol for http2
-        if (socket.alpnProtocol && (socket.alpnProtocol === 'h2' || socket.alpnProtocol === 'h2c')) {
+        if (alpnProtocol === 'h2' || alpnProtocol === 'h2c') {
             setPrototypeOf(req, app.http2Request)
             setPrototypeOf(res, app.http2Response)
         } else {


### PR DESCRIPTION
for insecure createServer imported from http2, so that h2c works correctly.

Old code was causing the protocol to return null when createServer was used.


New code works in node 16 for both createServer and createSecureServer